### PR TITLE
Fix tabs with spaces in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -577,15 +577,14 @@ jobs:
         with:
           submodules: 'true'
       - name: Build Flatpak (Linux)
-      	if: inputs.build_type == 'Release'
+        if: inputs.build_type == 'Release'
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: "PollyMC.flatpak"
           manifest-path: flatpak/org.fn2006.PollyMC.yml
-
       - name: Upload Flatpak (Linux)
-	if: runner.os == 'Linux' && matrix.qt_ver != 5
-	uses: actions/upload-artifact@v3
-	with:
-	  name: PollyMC-${{ env.VERSION }}-x86_64.flatpak
-	  path: PollyMC.flatpak
+        if: runner.os == 'Linux' && matrix.qt_ver != 5
+        uses: actions/upload-artifact@v3
+        with:
+          name: PollyMC-${{ env.VERSION }}-x86_64.flatpak
+          path: PollyMC.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,6 @@
 name: Build
 
-on: 
-  workflow_dispatch:
-    inputs:
-      build_type:
-        description: Type of build (Debug, Release, RelWithDebInfo, MinSizeRel)
-        type: string
-        default: Debug
-      is_qt_cached:
-        description: Enable Qt caching or not
-        type: string
-        default: true
+on: workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
-on:
-  workflow_call:
+on: 
+  workflow_dispatch:
     inputs:
       build_type:
         description: Type of build (Debug, Release, RelWithDebInfo, MinSizeRel)
@@ -11,19 +11,6 @@ on:
         description: Enable Qt caching or not
         type: string
         default: true
-    secrets:
-      SPARKLE_ED25519_KEY:
-        description: Private key for signing Sparkle updates
-        required: false
-      WINDOWS_CODESIGN_CERT:
-        description: Certificate for signing Windows builds
-        required: false
-      WINDOWS_CODESIGN_PASSWORD:
-        description: Password for signing Windows builds
-        required: false
-      CACHIX_AUTH_TOKEN:
-        description: Private token for authenticating against Cachix cache
-        required: false
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,29 @@
 name: Build
 
-on: workflow_dispatch
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        description: Type of build (Debug, Release, RelWithDebInfo, MinSizeRel)
+        type: string
+        default: Debug
+      is_qt_cached:
+        description: Enable Qt caching or not
+        type: string
+        default: true
+    secrets:
+      SPARKLE_ED25519_KEY:
+        description: Private key for signing Sparkle updates
+        required: false
+      WINDOWS_CODESIGN_CERT:
+        description: Certificate for signing Windows builds
+        required: false
+      WINDOWS_CODESIGN_PASSWORD:
+        description: Password for signing Windows builds
+        required: false
+      CACHIX_AUTH_TOKEN:
+        description: Private token for authenticating against Cachix cache
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
I [too would really like a Flatpak](https://github.com/fn2006/PollyMC/issues/24#issuecomment-1442193058) now that FTB is off of Prism :pray: 

Cleaned up the tabs from the newly edited Flatpak action on `build.yml`. It parses now, and the flatpak itself builds on my fork. Unfortunately every other build target fails due to various reasons for me :disappointed: 

Hope this makes an _official_ PollyMC Flatpak release channel go smoother :crossed_fingers: 