### PR TITLE
Unmojang authlib-injector cleanup

### DIFF
--- a/launcher/CreateAuthlibInjectorAccount.h
+++ b/launcher/CreateAuthlibInjectorAccount.h
@@ -30,8 +30,8 @@ class CreateAuthlibInjectorAccount : public NetAction {
         return CreateAuthlibInjectorAccountPtr(new CreateAuthlibInjectorAccount(url, account, username));
     }
     MinecraftAccountPtr getAccount();
-    
-    void init() override {};
+
+    void init() override{};
 
    protected slots:
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal) override {}

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -38,10 +38,10 @@
 #include <tools/BaseProfiler.h>
 #include <QObject>
 
-#include "minecraft/auth/MinecraftAccount.h"
-#include "minecraft/launch/MinecraftServerTarget.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
+#include "minecraft/auth/MinecraftAccount.h"
+#include "minecraft/launch/MinecraftServerTarget.h"
 
 class InstanceWindow;
 class LaunchController : public Task {

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -533,32 +533,28 @@ QString MinecraftInstance::getLauncher()
 QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
-    if(session->uses_custom_api_servers)
-    {
+    if (session->uses_custom_api_servers) {
         args << "-Dminecraft.api.env=custom";
         args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
         args << "-Dminecraft.api.account.host=" + session->account_server_url;
         args << "-Dminecraft.api.session.host=" + session->session_server_url;
         args << "-Dminecraft.api.services.host=" + session->services_server_url;
         auto agents = m_components->getProfile()->getAgents();
-        for (auto agent : agents)
-        {
-            if (agent->library()->artifactPrefix() == "moe.yushi:authlibinjector")
-            {
+        for (auto agent : agents) {
+            if (agent->library()->artifactPrefix() == "moe.yushi:authlibinjector") {
                 QStringList jar, temp1, temp2, temp3;
                 agent->library()->getApplicableFiles(runtimeContext(), jar, temp1, temp2, temp3, getLocalLibraryPath());
-                QString argument{agent->argument()};
+                QString argument{ agent->argument() };
                 if (argument.isEmpty()) {
                     argument = session->authlib_injector_url;
                 }
-                args << "-javaagent:"+jar[0]+(argument.isEmpty() ? "" : "="+argument);
+                args << "-javaagent:" + jar[0] + (argument.isEmpty() ? "" : "=" + argument);
                 if (session->authlib_injector_metadata != "") {
-                    args << "-Dauthlibinjector.yggdrasil.prefetched="+session->authlib_injector_metadata;
+                    args << "-Dauthlibinjector.yggdrasil.prefetched=" + session->authlib_injector_metadata;
                 }
             }
             break;
         }
-
     }
     return args;
 }

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -35,15 +35,15 @@
  */
 
 #pragma once
-#include <unordered_set>
 #include <java/JavaVersion.h>
 #include <QDir>
 #include <QProcess>
+#include <unordered_set>
 #include "BaseInstance.h"
 #include "minecraft/launch/MinecraftServerTarget.h"
 #include "minecraft/mod/Mod.h"
 
-const std::unordered_set<std::string> MANAGED_AGENTS = {"moe.yushi:authlibinjector"};
+const std::unordered_set<std::string> MANAGED_AGENTS = { "moe.yushi:authlibinjector" };
 
 class ModFolderModel;
 class ResourceFolderModel;

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -124,17 +124,17 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
     // override/replace existing account with the same profileId
     auto profileId = account->profileId();
     if (profileId.size() && account->isMojangOrMSA()) {
-        auto iter = std::find_if(m_accounts.constBegin(), m_accounts.constEnd(), [&](const MinecraftAccountPtr & existing) {
+        auto iter = std::find_if(m_accounts.constBegin(), m_accounts.constEnd(), [&](const MinecraftAccountPtr& existing) {
             return existing->profileId() == profileId && existing->isMojangOrMSA();
         });
 
-        if(iter != m_accounts.constEnd()) {
+        if (iter != m_accounts.constEnd()) {
             qDebug() << "Replacing old account with a new one with the same profile ID!";
 
             MinecraftAccountPtr existingAccount = *iter;
             const auto existingAccountIndex = std::distance(m_accounts.constBegin(), iter);
             m_accounts[existingAccountIndex] = account;
-            if(m_defaultAccount == existingAccount) {
+            if (m_defaultAccount == existingAccount) {
                 m_defaultAccount = account;
             }
             // disconnect notifications for changes in the account being replaced

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -86,10 +86,7 @@ class MinecraftAccount : public QObject, public Usable {
     explicit MinecraftAccount(QObject* parent = 0);
 
     static MinecraftAccountPtr createFromUsername(const QString& username);
-    static MinecraftAccountPtr createFromUsernameAuthlibInjector(
-        const QString& username,
-        const QString& authlibInjectorUrl
-    );
+    static MinecraftAccountPtr createFromUsernameAuthlibInjector(const QString& username, const QString& authlibInjectorUrl);
 
     static MinecraftAccountPtr createBlankMSA();
 
@@ -123,29 +120,17 @@ class MinecraftAccount : public QObject, public Usable {
    public: /* queries */
     QString internalId() const { return data.internalId; }
 
-    QString authlibInjectorUrl() const {
-        return data.authlibInjectorUrl;
-    }
+    QString authlibInjectorUrl() const { return data.authlibInjectorUrl; }
 
-    QString authServerUrl() const {
-        return data.authServerUrl();
-    }
+    QString authServerUrl() const { return data.authServerUrl(); }
 
-    QString accountServerUrl() const {
-        return data.accountServerUrl();
-    }
+    QString accountServerUrl() const { return data.accountServerUrl(); }
 
-    QString sessionServerUrl() const {
-        return data.sessionServerUrl();
-    }
+    QString sessionServerUrl() const { return data.sessionServerUrl(); }
 
-    QString servicesServerUrl() const {
-        return data.servicesServerUrl();
-    }
+    QString servicesServerUrl() const { return data.servicesServerUrl(); }
 
-    bool usesCustomApiServers() const {
-        return data.usesCustomApiServers();
-    }
+    bool usesCustomApiServers() const { return data.usesCustomApiServers(); }
 
     QString accountDisplayString() const { return data.accountDisplayString(); }
 
@@ -175,7 +160,7 @@ class MinecraftAccount : public QObject, public Usable {
     {
         switch (data.type) {
             case AccountType::Mojang: {
-                if(data.legacy) {
+                if (data.legacy) {
                     return "Legacy";
                 }
                 return "Mojang";

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -25,8 +25,8 @@
 
 #include <QDebug>
 
-#include "BuildConfig.h"
 #include "Application.h"
+#include "BuildConfig.h"
 
 Yggdrasil::Yggdrasil(AccountData* data, QObject* parent) : AccountTask(data, parent)
 {

--- a/launcher/minecraft/auth/flows/AuthlibInjector.cpp
+++ b/launcher/minecraft/auth/flows/AuthlibInjector.cpp
@@ -1,25 +1,21 @@
 #include "AuthlibInjector.h"
 
-#include "minecraft/auth/steps/YggdrasilStep.h"
-#include "minecraft/auth/steps/MinecraftProfileStepMojang.h"
-#include "minecraft/auth/steps/GetSkinStep.h"
 #include "minecraft/auth/steps/AuthlibInjectorMetadataStep.h"
+#include "minecraft/auth/steps/GetSkinStep.h"
+#include "minecraft/auth/steps/MinecraftProfileStepMojang.h"
+#include "minecraft/auth/steps/YggdrasilStep.h"
 
-AuthlibInjectorRefresh::AuthlibInjectorRefresh(
-    AccountData *data,
-    QObject *parent
-) : AuthFlow(data, parent) {
+AuthlibInjectorRefresh::AuthlibInjectorRefresh(AccountData* data, QObject* parent) : AuthFlow(data, parent)
+{
     m_steps.append(makeShared<YggdrasilStep>(m_data, QString()));
     m_steps.append(makeShared<MinecraftProfileStepMojang>(m_data));
     m_steps.append(makeShared<AuthlibInjectorMetadataStep>(m_data));
     m_steps.append(makeShared<GetSkinStep>(m_data));
 }
 
-AuthlibInjectorLogin::AuthlibInjectorLogin(
-    AccountData *data,
-    QString password,
-    QObject *parent
-): AuthFlow(data, parent), m_password(password) {
+AuthlibInjectorLogin::AuthlibInjectorLogin(AccountData* data, QString password, QObject* parent)
+    : AuthFlow(data, parent), m_password(password)
+{
     m_steps.append(makeShared<YggdrasilStep>(m_data, m_password));
     m_steps.append(makeShared<MinecraftProfileStepMojang>(m_data));
     m_steps.append(makeShared<AuthlibInjectorMetadataStep>(m_data));

--- a/launcher/minecraft/auth/flows/AuthlibInjector.h
+++ b/launcher/minecraft/auth/flows/AuthlibInjector.h
@@ -1,26 +1,17 @@
 #pragma once
 #include "AuthFlow.h"
 
-class AuthlibInjectorRefresh : public AuthFlow
-{
+class AuthlibInjectorRefresh : public AuthFlow {
     Q_OBJECT
-public:
-    explicit AuthlibInjectorRefresh(
-        AccountData *data,
-        QObject *parent = 0
-    );
+   public:
+    explicit AuthlibInjectorRefresh(AccountData* data, QObject* parent = 0);
 };
 
-class AuthlibInjectorLogin : public AuthFlow
-{
+class AuthlibInjectorLogin : public AuthFlow {
     Q_OBJECT
-public:
-    explicit AuthlibInjectorLogin(
-        AccountData *data,
-        QString password,
-        QObject *parent = 0
-    );
+   public:
+    explicit AuthlibInjectorLogin(AccountData* data, QString password, QObject* parent = 0);
 
-private:
+   private:
     QString m_password;
 };

--- a/launcher/minecraft/auth/steps/AuthlibInjectorMetadataStep.h
+++ b/launcher/minecraft/auth/steps/AuthlibInjectorMetadataStep.h
@@ -4,12 +4,11 @@
 #include "QObjectPtr.h"
 #include "minecraft/auth/AuthStep.h"
 
-
 class AuthlibInjectorMetadataStep : public AuthStep {
     Q_OBJECT
 
-public:
-    explicit AuthlibInjectorMetadataStep(AccountData *data);
+   public:
+    explicit AuthlibInjectorMetadataStep(AccountData* data);
     virtual ~AuthlibInjectorMetadataStep() noexcept;
 
     void perform() override;
@@ -17,6 +16,6 @@ public:
 
     QString describe() override;
 
-private slots:
+   private slots:
     void onRequestDone(QNetworkReply::NetworkError, QByteArray, QList<QNetworkReply::RawHeaderPair>);
 };

--- a/launcher/minecraft/services/CapeChange.h
+++ b/launcher/minecraft/services/CapeChange.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <minecraft/auth/MinecraftAccount.h>
 #include <QFile>
 #include <QtNetwork/QtNetwork>
 #include <memory>
 #include "QObjectPtr.h"
 #include "tasks/Task.h"
-#include <minecraft/auth/MinecraftAccount.h>
 
 class CapeChange : public Task {
     Q_OBJECT

--- a/launcher/minecraft/services/SkinDelete.h
+++ b/launcher/minecraft/services/SkinDelete.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <minecraft/auth/MinecraftAccount.h>
 #include <QFile>
 #include <QtNetwork/QtNetwork>
 #include "tasks/Task.h"
-#include <minecraft/auth/MinecraftAccount.h>
 
 typedef shared_qobject_ptr<class SkinDelete> SkinDeletePtr;
 

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -381,12 +381,7 @@ void VersionPage::on_actionChange_version_triggered()
         return;
     }
     auto uid = list->uid();
-    // FIXME: this is a horrible HACK. Get version filtering information from the actual metadata...
-    // unsure if the above comment still applies
-    if (uid == "moe.yushi.authlibinjector") {
-        on_actionInstall_AuthlibInjector_triggered();
-        return;
-    }
+
     VersionSelectDialog vselect(list.get(), tr("Change %1 version").arg(name), this);
     if (uid == "net.fabricmc.intermediary" || uid == "org.quiltmc.hashed") {
         vselect.setEmptyString(tr("No intermediary mappings versions are currently available."));
@@ -428,8 +423,7 @@ void VersionPage::on_actionDownload_All_triggered()
 void VersionPage::openInstallAuthlibInjector()
 {
     auto vlist = APPLICATION->metadataIndex()->get("moe.yushi.authlibinjector");
-    if(!vlist)
-    {
+    if (!vlist) {
         return;
     }
     VersionSelectDialog vselect(vlist.get(), tr("Select authlib-injector version"), this);
@@ -437,17 +431,15 @@ void VersionPage::openInstallAuthlibInjector()
     vselect.setEmptyErrorString(tr("Couldn't load or download the authlib-injector version lists!"));
 
     auto currentVersion = m_profile->getComponentVersion("moe.yushi.authlibinjector");
-    if(!currentVersion.isEmpty())
-    {
+    if (!currentVersion.isEmpty()) {
         vselect.setCurrentVersion(currentVersion);
     }
 
-    if (vselect.exec() && vselect.selectedVersion())
-    {
+    if (vselect.exec() && vselect.selectedVersion()) {
         auto vsn = vselect.selectedVersion();
         m_profile->setComponentVersion("moe.yushi.authlibinjector", vsn->descriptor());
         m_profile->resolve(Net::Mode::Online);
-        preselect(m_profile->rowCount(QModelIndex())-1);
+        preselect(m_profile->rowCount(QModelIndex()) - 1);
         m_container->refreshContainer();
     }
 }


### PR DESCRIPTION
Cleans up a couple things from merging my fork, including fixing the "Don't ask again" checkbox in the "Missing authlib-injector" dialog (oversight on my part), and a clang-format.

Did you want to keep the DRM check for authlib-injector accounts? Currently it won't let you add an authlib-injector account without first adding a Mojang or Microsoft account. Up to you.