### PR TITLE
fix Nix wrapper using wrong JAVA_PATHS env var

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -154,7 +154,7 @@ JavaInstallPtr JavaUtils::GetDefaultJava()
 
 QStringList addJavasFromEnv(QList<QString> javas)
 {
-    auto env = qEnvironmentVariable("PRISMLAUNCHER_JAVA_PATHS");  // FIXME: use launcher name from buildconfig
+    auto env = qEnvironmentVariable("POLLYMC_JAVA_PATHS");  // FIXME: use launcher name from buildconfig
 #if defined(Q_OS_WIN32)
     QList<QString> javaPaths = env.replace("\\", "/").split(QLatin1String(";"));
 

--- a/nix/pkg/wrapper.nix
+++ b/nix/pkg/wrapper.nix
@@ -80,7 +80,7 @@ in
         ]
         ++ additionalPrograms;
     in
-      ["--prefix pollymc_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
+      ["--prefix POLLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
       ++ lib.optionals stdenv.isLinux [
         "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${lib.makeLibraryPath runtimeLibs}"
         # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128


### PR DESCRIPTION
This fixes the currently broken Nix derivation created by PollyMC not finding any java installations, due to the interface providing the arg `pollymc_JAVA_PATHS` but the launcher only looking for `PRISMLAUNCHER_JAVA_PATHS`. Seems to be a search-and-replace lost in translation, possibly related to #92 being merged only yesterday.