### PR TITLE
unmojang: Automatically install authlib-injector when missing

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -115,6 +115,7 @@
 #include "tools/MCEditTool.h"
 
 #include "settings/INISettingsObject.h"
+#include "settings/MissingAuthlibInjectorBehavior.h"
 #include "settings/Setting.h"
 
 #include "meta/Index.h"
@@ -601,6 +602,9 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         // Minecraft mods
         m_settings->registerSetting("ModMetadataDisabled", false);
 
+        // Missing authlib-injector behavior
+        m_settings->registerSetting("MissingAuthlibInjectorBehavior", MissingAuthlibInjectorBehavior::Ask);
+
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");
 
@@ -982,12 +986,10 @@ void Application::performMainStartupAction()
     }
     {
         bool shouldFetch = m_settings->get("FlameKeyShouldBeFetchedOnStartup").toBool();
-        if (!BuildConfig.FLAME_API_KEY_API_URL.isEmpty() && shouldFetch && !(capabilities() & Capability::SupportsFlame))
-        {
+        if (!BuildConfig.FLAME_API_KEY_API_URL.isEmpty() && shouldFetch && !(capabilities() & Capability::SupportsFlame)) {
             // don't ask, just fetch
             QString apiKey = GuiUtil::fetchFlameKey();
-            if (!apiKey.isEmpty())
-            {
+            if (!apiKey.isEmpty()) {
                 m_settings->set("FlameKeyOverride", apiKey);
                 updateCapabilities();
             }

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -103,8 +103,6 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     m_settings->registerSetting("ManagedPackVersionName", "");
 
     m_settings->registerSetting("Profiler", "");
-
-    m_settings->registerSetting("SuggestAuthlibInjector", true);
 }
 
 QString BaseInstance::getPreLaunchCommand()

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -430,6 +430,7 @@ set(SETTINGS_SOURCES
     settings/Setting.h
     settings/SettingsObject.cpp
     settings/SettingsObject.h
+    settings/MissingAuthlibInjectorBehavior.h
 )
 
 set(JAVA_SOURCES

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -37,6 +37,8 @@
  *      limitations under the License.
  */
 
+#include "Application.h"
+
 #include <Version.h>
 #include <QCryptographicHash>
 #include <QDebug>

--- a/launcher/settings/MissingAuthlibInjectorBehavior.h
+++ b/launcher/settings/MissingAuthlibInjectorBehavior.h
@@ -1,0 +1,7 @@
+#pragma once
+
+enum MissingAuthlibInjectorBehavior {
+    Ask,
+    Ignore,
+    Install,
+};

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -48,6 +48,7 @@
 #include "Application.h"
 #include "BuildConfig.h"
 #include "DesktopServices.h"
+#include "settings/MissingAuthlibInjectorBehavior.h"
 #include "settings/SettingsObject.h"
 #include "ui/themes/ITheme.h"
 #include "updater/ExternalUpdater.h"
@@ -76,6 +77,11 @@ LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::Launch
     defaultFormat = new QTextCharFormat(ui->fontPreview->currentCharFormat());
 
     m_languageModel = APPLICATION->translations();
+
+    ui->missingAIComboBox->addItem("Always ask", MissingAuthlibInjectorBehavior::Ask);
+    ui->missingAIComboBox->addItem("Ignore missing authlib-injector", MissingAuthlibInjectorBehavior::Ignore);
+    ui->missingAIComboBox->addItem("Automatically install authlib-injector", MissingAuthlibInjectorBehavior::Install);
+
     loadSettings();
 
     ui->updateSettingsBox->setHidden(!APPLICATION->updater());
@@ -220,6 +226,9 @@ void LauncherPage::applySettings()
 
     // Mods
     s->set("ModMetadataDisabled", ui->metadataDisableBtn->isChecked());
+
+    // authlib-injector
+    s->set("MissingAuthlibInjectorBehavior", ui->missingAIComboBox->currentData().toInt());
 }
 void LauncherPage::loadSettings()
 {
@@ -272,6 +281,14 @@ void LauncherPage::loadSettings()
     // Mods
     ui->metadataDisableBtn->setChecked(s->get("ModMetadataDisabled").toBool());
     ui->metadataWarningLabel->setHidden(!ui->metadataDisableBtn->isChecked());
+
+    // Missing authlib-injector behavior
+    int missingAI = s->get("MissingAuthlibInjectorBehavior").toInt();
+    int missingAIIndex = ui->missingAIComboBox->findData(missingAI);
+    if (missingAIIndex == -1) {
+        missingAIIndex = ui->missingAIComboBox->findData(MissingAuthlibInjectorBehavior::Ask);
+    }
+    ui->missingAIComboBox->setCurrentIndex(missingAIIndex);
 }
 
 void LauncherPage::refreshFontPreview()

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -190,6 +190,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="authlibInjectorBox">
+         <property name="title">
+          <string>Missing authlib-injector behavior</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QComboBox" name="missingAIComboBox">
+            <property name="toolTip">
+             <string>What to do when using an authlib-injector account with an instance that does not have authlib-injector installed</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -262,8 +262,6 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("DisableQuiltBeacon");
     }
 
-    m_settings->set("SuggestAuthlibInjector", ui->suggestAuthlibInjector->isChecked());
-
     // FIXME: This should probably be called by a signal instead
     m_instance->updateRuntimeContext();
 }
@@ -371,8 +369,6 @@ void InstanceSettingsPage::loadSettings()
     // Mod loader specific settings
     ui->modLoaderSettingsGroupBox->setChecked(m_settings->get("OverrideModLoaderSettings").toBool());
     ui->disableQuiltBeaconCheckBox->setChecked(m_settings->get("DisableQuiltBeacon").toBool());
-
-    ui->suggestAuthlibInjector->setChecked(m_settings->get("SuggestAuthlibInjector").toBool());
 }
 
 void InstanceSettingsPage::on_javaDetectBtn_clicked()

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -711,16 +711,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="suggestAuthlibInjector">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Suggest installing authlib-injector when using custom API servers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Suggest Authlib Injector</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacerMiscellaneous">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Scenario: user tries to launch an instance with an authlib-injector account, but authlib-injector is not installed on the instance.

Current behavior: a dialog box is shown asking whether the user wants to install authlib-injector. If they check "Don't ask again", missing authlib-injector will always be ignored for that instance. If they click "Yes", launching the instance is cancelled and a dialog to select a version of authlib-injector is shown. 

Proposed behavior: the checkbox is changed to "Always do the same for all instances without asking" and controls a global setting called "Missing authlib-injector behavior". The "Yes" button automatically installs the latest version of authlib-injector[0] and continues launching the instance. The global "Missing authlib-injector behavior" setting can be set to:
- Always ask
- Ignore missing authlib-injector
- Automatically install authlib-injector

A custom version of authlib-injector can still be installed in the "Edit Instance" menu, as before.

[0] I couldn't get the launcher to choose the latest version, possibly related to https://github.com/yushijinhun/authlib-injector/issues/219. I'd like to fix this before unmojang is merged to develop, but in the meantime I've changed the metadata server to only list the latest version of authlib-injector, currently 1.2.3.