### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -311,7 +311,7 @@ QString MinecraftInstance::getLocalLibraryPath() const
 bool MinecraftInstance::supportsDemo() const
 {
     Version instance_ver{ getPackProfile()->getComponentVersion("net.minecraft") };
-    // Demo mode was introduced in 1.3.1: https://minecraft.fandom.com/wiki/Demo_mode#History
+    // Demo mode was introduced in 1.3.1: https://minecraft.wiki/w/Demo_mode#History
     // FIXME: Due to Version constraints atm, this can't handle well non-release versions
     return instance_ver >= Version("1.3.1");
 }

--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -28,7 +28,7 @@
 #include "Version.h"
 
 // Values taken from:
-// https://minecraft.fandom.com/wiki/Tutorials/Creating_a_data_pack#%22pack_format%22
+// https://minecraft.wiki/w/Tutorials/Creating_a_data_pack#%22pack_format%22
 static const QMap<int, std::pair<Version, Version>> s_pack_format_versions = {
     { 4, { Version("1.13"), Version("1.14.4") } },    { 5, { Version("1.15"), Version("1.16.1") } },
     { 6, { Version("1.16.2"), Version("1.16.5") } },  { 7, { Version("1.17"), Version("1.17.1") } },

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -63,7 +63,7 @@ class DataPack : public Resource {
     mutable QMutex m_data_lock;
 
     /* The 'version' of a data pack, as defined in the pack.mcmeta file.
-     * See https://minecraft.fandom.com/wiki/Data_pack#pack.mcmeta
+     * See https://minecraft.wiki/w/Data_pack#pack.mcmeta
      */
     int m_pack_format = 0;
 

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -11,7 +11,7 @@
 #include "minecraft/mod/tasks/LocalResourcePackParseTask.h"
 
 // Values taken from:
-// https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+// https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 static const QMap<int, std::pair<Version, Version>> s_pack_format_versions = {
     { 1, { Version("1.6.1"), Version("1.8.9") } },    { 2, { Version("1.9"), Version("1.10.2") } },
     { 3, { Version("1.11"), Version("1.12.2") } },    { 4, { Version("1.13"), Version("1.14.4") } },

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -51,7 +51,7 @@ class ResourcePack : public Resource {
     mutable QMutex m_data_lock;
 
     /* The 'version' of a resource pack, as defined in the pack.mcmeta file.
-     * See https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+     * See https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
      */
     int m_pack_format = 0;
 

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -133,7 +133,7 @@ bool processZIP(DataPack& pack, ProcessingLevel level)
     return true;
 }
 
-// https://minecraft.fandom.com/wiki/Data_pack#pack.mcmeta
+// https://minecraft.wiki/w/Data_pack#pack.mcmeta
 bool processMCMeta(DataPack& pack, QByteArray&& raw_data)
 {
     try {

--- a/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
@@ -178,7 +178,7 @@ bool processZIP(ResourcePack& pack, ProcessingLevel level)
     return true;
 }
 
-// https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+// https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 bool processMCMeta(ResourcePack& pack, QByteArray&& raw_data)
 {
     try {

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -158,12 +158,12 @@ QString InfoFrame::renderColorCodes(QString input)
     //
     // TODO: Wrap links inside <a> tags
 
-    // https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes
+    // https://minecraft.wiki/w/Formatting_codes#Color_codes
     const QMap<QChar, QString> color_codes_map = { { '0', "#000000" }, { '1', "#0000AA" }, { '2', "#00AA00" }, { '3', "#00AAAA" },
                                                    { '4', "#AA0000" }, { '5', "#AA00AA" }, { '6', "#FFAA00" }, { '7', "#AAAAAA" },
                                                    { '8', "#555555" }, { '9', "#5555FF" }, { 'a', "#55FF55" }, { 'b', "#55FFFF" },
                                                    { 'c', "#FF5555" }, { 'd', "#FF55FF" }, { 'e', "#FFFF55" }, { 'f', "#FFFFFF" } };
-    // https://minecraft.fandom.com/wiki/Formatting_codes#Formatting_codes
+    // https://minecraft.wiki/w/Formatting_codes#Formatting_codes
     const QMap<QChar, QString> formatting_codes_map = { { 'l', "b" }, { 'm', "s" }, { 'n', "u" }, { 'o', "i" } };
 
     QString html("<html>");


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.