### PR TITLE
Smooth Ely.by -> authlib-injector migration

### DIFF
--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -348,12 +348,17 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
         return false;
     }
     auto typeS = typeV.toString();
+    bool needsElyByMigration = false;
     if (typeS == "MSA") {
         type = AccountType::MSA;
     } else if (typeS == "Mojang") {
         type = AccountType::Mojang;
     } else if (typeS == "AuthlibInjector") {
         type = AccountType::AuthlibInjector;
+    } else if (typeS == "Elyby") {
+        // Migrate legacy Ely.by accounts to authlib-injector accounts
+        type = AccountType::AuthlibInjector;
+        needsElyByMigration = true;
     } else if (typeS == "Offline") {
         type = AccountType::Offline;
     } else {
@@ -367,12 +372,21 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
     }
 
     if (type == AccountType::AuthlibInjector) {
-        customAuthServerUrl = data.value("customAuthServerUrl").toString();
-        customAccountServerUrl = data.value("customAccountServerUrl").toString();
-        customSessionServerUrl = data.value("customSessionServerUrl").toString();
-        customServicesServerUrl = data.value("customServicesServerUrl").toString();
-        authlibInjectorUrl = data.value("authlibInjectorUrl").toString();
-        authlibInjectorMetadata = data.value("authlibInjectorMetadata").toString();
+        if (needsElyByMigration) {
+            customAuthServerUrl = "https://authserver.ely.by/api/authlib-injector/authserver";
+            customAccountServerUrl = "https://authserver.ely.by/api/authlib-injector/api";
+            customSessionServerUrl = "https://authserver.ely.by/api/authlib-injector/sessionserver";
+            customServicesServerUrl = "https://authserver.ely.by/api/authlib-injector/minecraftservices";
+            authlibInjectorUrl = "https://authserver.ely.by/api/authlib-injector";
+            authlibInjectorMetadata = "";
+        } else {
+            customAuthServerUrl = data.value("customAuthServerUrl").toString();
+            customAccountServerUrl = data.value("customAccountServerUrl").toString();
+            customSessionServerUrl = data.value("customSessionServerUrl").toString();
+            customServicesServerUrl = data.value("customServicesServerUrl").toString();
+            authlibInjectorUrl = data.value("authlibInjectorUrl").toString();
+            authlibInjectorMetadata = data.value("authlibInjectorMetadata").toString();
+        }
     }
 
     if (type == AccountType::MSA) {

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -292,6 +292,9 @@ bool MinecraftAccount::shouldRefresh() const
     if (isInUse()) {
         return false;
     }
+    if (data.type == AccountType::AuthlibInjector && data.authlibInjectorMetadata == "") {
+        return true;
+    }
     switch (data.validity_) {
         case Katabasis::Validity::Certain: {
             break;


### PR DESCRIPTION
Automatically migrate Ely.by accounts to authlib-injector.

Is there anything else we should do so Ely.by users aren't as confused about the update? https://github.com/fn2006/PollyMC/pull/116#issuecomment-1811999598 mentions that the 2FA field is no longer there. We could add it back, but who knows whether other auth servers also implement 2FA the same way, it might not make sense long-term.

Maybe an additional message specifically explaining 2FA on Ely.by on the "Add authlib-injector" dialog would be best.