### PR TITLE
Fix authlib-injector not working w/other Java agents

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -562,8 +562,8 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
                 if (session->authlib_injector_metadata != "") {
                     args << "-Dauthlibinjector.yggdrasil.prefetched=" + session->authlib_injector_metadata;
                 }
+                break;
             }
-            break;
         }
     }
     return args;


### PR DESCRIPTION
One last bug fix: `break` statement was in the wrong place here. This fixes authlib-injector not working if it's not the first Java agent in the list.