### PR TITLE
Fix extension points and Java auto-detect in Flatpak

### DIFF
--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -3,8 +3,9 @@ runtime: org.kde.Platform
 runtime-version: "5.15-23.08"
 sdk: org.kde.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
+  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
     version: "23.08"
@@ -20,7 +21,7 @@ add-extensions:
     add-ld-path: lib
     directory: utils/mangohud
 
-command: pollymc
+command: pollyrun
 finish-args:
   - --share=ipc
   - --socket=wayland
@@ -64,6 +65,8 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/jdk/
+      - /usr/lib/sdk/openjdk21/install.sh
+      - mv /app/jre /app/jdk/21
       - /usr/lib/sdk/openjdk17/install.sh
       - mv /app/jre /app/jdk/17
       - /usr/lib/sdk/openjdk8/install.sh
@@ -155,14 +158,13 @@ modules:
   - name: enhance
     buildsystem: simple
     build-commands:
-      - install -Dm755 prime-run /app/bin/prime-run
-      - mv /app/bin/pollymc /app/bin/pollyrun
-      - install -Dm755 pollymc /app/bin/pollymc
+      - install -Dm755 prime-run -t /app/bin
+      - install -Dm755 pollyrun -t /app/bin
     sources:
       - type: file
         path: prime-run
       - type: file
-        path: pollymc
+        path: pollyrun
 
   - name: extensions
     buildsystem: simple

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -1,20 +1,20 @@
 id: org.fn2006.PollyMC
 runtime: org.kde.Platform
-runtime-version: "5.15-22.08"
+runtime-version: "5.15-23.08"
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
-    version: "22.08"
+    version: "23.08"
     no-autodownload: true
     autodelete: false
     add-ld-path: lib
     directory: utils/gamescope
 
   org.freedesktop.Platform.VulkanLayer.MangoHud:
-    version: "22.08"
+    version: "23.08"
     no-autodownload: true
     autodelete: false
     add-ld-path: lib
@@ -116,16 +116,10 @@ modules:
       # post-install is running inside the build dir, we need it from the source though
       - install -Dm755 ../data/gamemoderun -t /app/bin
     sources:
-      - type: archive
-        archive-type: tar-gzip
-        url: https://api.github.com/repos/FeralInteractive/gamemode/tarball/1.7
-        sha256: 57ce73ba605d1cf12f8d13725006a895182308d93eba0f69f285648449641803
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/FeralInteractive/gamemode/releases/latest
-          version-query: .tag_name
-          url-query: .tarball_url
-          timestamp-query: .published_at
+      - type: git
+        url: https://github.com/FeralInteractive/gamemode.git
+        tag: 1.8.1
+        commit: 5180d89e66830d87f69687b95fb86f622552b94b
     cleanup:
       - /include
       - /lib/pkgconfig

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -16,8 +16,8 @@ add-extensions:
 command: pollymc
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --device=all
   - --share=network
   - --socket=pulseaudio

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -32,6 +32,8 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
     # Mod drag&drop
   - --filesystem=xdg-download:ro
+  - --env=PATH=/app/bin:/usr/bin:/app/utils/gamescope/bin:/app/utils/mangohud/bin
+  - --env=VK_LAYER_PATH=/usr/lib/extensions/vulkan/share/vulkan/implicit_layer.d
 
 cleanup:
   - /lib/libGLU*
@@ -167,3 +169,8 @@ modules:
         path: prime-run
       - type: file
         path: pollymc
+
+  - name: extensions
+    buildsystem: simple
+    build-commands:
+      - mkdir -p ${FLATPAK_DEST}/utils/{gamescope,mangohud}

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -59,8 +59,7 @@ modules:
       - mv /app/jre /app/jdk/17
       - /usr/lib/sdk/openjdk8/install.sh
       - mv /app/jre /app/jdk/8
-    cleanup:
-      - /jre
+      - rm -rf /app/jdk/8/bin
 
   - name: glfw
     buildsystem: cmake-ninja

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -13,6 +13,13 @@ add-extensions:
     add-ld-path: lib
     directory: utils/gamescope
 
+  org.freedesktop.Platform.VulkanLayer.MangoHud:
+    version: "22.08"
+    no-autodownload: true
+    autodelete: false
+    add-ld-path: lib
+    directory: utils/mangohud
+
 command: pollymc
 finish-args:
   - --share=ipc

--- a/flatpak/org.fn2006.PollyMC.yml
+++ b/flatpak/org.fn2006.PollyMC.yml
@@ -6,11 +6,11 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
 add-extensions:
-  com.valvesoftware.Steam.Utility.gamescope:
-    version: stable
-    add-ld-path: lib
+  org.freedesktop.Platform.VulkanLayer.gamescope:
+    version: "22.08"
     no-autodownload: true
     autodelete: false
+    add-ld-path: lib
     directory: utils/gamescope
 
 command: pollymc

--- a/flatpak/pollymc
+++ b/flatpak/pollymc
@@ -5,7 +5,4 @@ for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/discord-ipc-"$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/discord-ipc-"$i";
 done
 
-export PATH="${PATH}${PATH:+:}/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/MangoHud/bin"
-export VK_LAYER_PATH="/usr/lib/extensions/vulkan/share/vulkan/implicit_layer.d/"
-
 exec /app/bin/pollyrun "$@"

--- a/flatpak/pollyrun
+++ b/flatpak/pollyrun
@@ -5,4 +5,4 @@ for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/discord-ipc-"$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/discord-ipc-"$i";
 done
 
-exec /app/bin/pollyrun "$@"
+exec /app/bin/pollymc "$@"


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Following changes have been made:

- replaced deprecated / EOL `com.valvesoftware.Steam.Utility.gamescope` extension
- added extension point for MangoHud
- moved ENV variables from starter script into manifest, this way PATH is set correctly also when I use a custom command inside the Flatpak
- fixed Java 8 appearing twice in the version selector auto-detect function thingy
- switched `x11` socket to `fallback-x11`, since `wayland` is the primary socket to use when available

Known issue:

I have not checked the source code yet, but for some reason, the MangoHud check is greyed out despite `mangohud` being in PATH and confirmed working by adding `mangohud --dlsym` to `Wrapper command`.

![Screenshot_20231230_161444](https://github.com/fn2006/PollyMC/assets/36563538/1a1eb102-cb26-452c-9a1d-ee888e5b3b83)

Maybe someone knows how PollyMC is checking if `mangohud` is available or not?
It is available in PATH:
```bash
$ flatpak run --command=bash org.fn2006.PollyMC 
[📦 org.fn2006.PollyMC ~]$ which mangohud
/app/utils/mangohud/bin/mangohud
```

**UPDATE**:
Issue is fixed with move to 23.08. Users have to have MangoHud flatpak installed 
```
flatpak install org.freedesktop.Platform.VulkanLayer.MangoHud//23.08
```
and then it will show up correctly in the settings:
![Screenshot_20240412_151956](https://github.com/fn2006/PollyMC/assets/36563538/c9d4791d-2103-4aa7-963d-0f8233a45319)