### PR TITLE
Add auth server column to account list

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -51,6 +51,7 @@
 
 #include <FileSystem.h>
 #include <QSaveFile>
+#include <QString>
 
 #include <chrono>
 
@@ -333,6 +334,17 @@ QVariant AccountList::data(const QModelIndex& index, int role) const
                     }
                 }
 
+                case AuthServerColumn: {
+                    QString suffix = "/authlib-injector/authserver";
+                    QString server = account->authServerUrl();
+                    if (server.endsWith(suffix)) {
+                        server.chop(suffix.length());
+                        return server;
+                    } else {
+                        return server;
+                    }
+                }
+
                 case MigrationColumn: {
                     if (!account->isMojang()) {
                         return tr("N/A", "Can Migrate");
@@ -379,6 +391,8 @@ QVariant AccountList::headerData(int section, [[maybe_unused]] Qt::Orientation o
                     return tr("Type");
                 case StatusColumn:
                     return tr("Status");
+                case AuthServerColumn:
+                    return tr("Server");
                 default:
                     return QVariant();
             }
@@ -393,6 +407,8 @@ QVariant AccountList::headerData(int section, [[maybe_unused]] Qt::Orientation o
                     return tr("Type of the account (MSA or Offline)");
                 case StatusColumn:
                     return tr("Current status of the account.");
+                case AuthServerColumn:
+                    return tr("Auth server the account is using.");
                 default:
                     return QVariant();
             }

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -58,6 +58,7 @@ class AccountList : public QAbstractListModel {
         MigrationColumn,
         TypeColumn,
         StatusColumn,
+        AuthServerColumn,
 
         NUM_COLUMNS
     };


### PR DESCRIPTION
I had a hard time distinguishing accounts with same names in account list so i added an auth server column.

![pollymc_account_list](https://github.com/fn2006/PollyMC/assets/52951851/256a64b2-7930-41ed-ac27-ba8c9e902855)
