### PR TITLE
fixes #63

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -543,12 +543,16 @@ QString MinecraftInstance::getLauncher()
 QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
+	QString v = m_components->getProfile()->getMinecraftVersion();
+	
     if (session->uses_custom_api_servers) {
-        args << "-Dminecraft.api.env=custom";
-        args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
-        args << "-Dminecraft.api.account.host=" + session->account_server_url;
-        args << "-Dminecraft.api.session.host=" + session->session_server_url;
-        args << "-Dminecraft.api.services.host=" + session->services_server_url;
+		if (v != "1.16.4" && v != "1.16.5") {
+			args << "-Dminecraft.api.env=custom";
+			args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
+			args << "-Dminecraft.api.account.host=" + session->account_server_url;
+			args << "-Dminecraft.api.session.host=" + session->session_server_url;
+			args << "-Dminecraft.api.services.host=" + session->services_server_url;
+		}
         auto agents = m_components->getProfile()->getAgents();
         for (auto agent : agents) {
             if (agent->library()->artifactPrefix() == "moe.yushi:authlibinjector") {


### PR DESCRIPTION
This pull request will fix #63, where Minecraft versions 1.16.4 and 1.16.5 will have the multiplayer options grayed out, when using authlib-injector accounts or offline mode accounts. It fixes the former only.