### PR TITLE
Fix offline multiplayer in 1.16.4-1.16.5

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -543,6 +543,8 @@ QString MinecraftInstance::getLauncher()
 QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
+    QString v = m_components->getProfile()->getMinecraftVersion();
+
     if (session->uses_custom_api_servers) {
         args << "-Dminecraft.api.env=custom";
         args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
@@ -565,6 +567,14 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
                 break;
             }
         }
+    } else if (session->wants_online && (v == "1.16.4" || v == "1.16.5")) {
+        // https://github.com/FabricMC/fabric-loom/issues/915#issuecomment-1609154390
+        QString invalid_url{ "https://invalid.invalid" };
+        args << "-Dminecraft.api.env=custom";
+        args << "-Dminecraft.api.auth.host=" + invalid_url;
+        args << "-Dminecraft.api.account.host=" + invalid_url;
+        args << "-Dminecraft.api.session.host=" + invalid_url;
+        args << "-Dminecraft.api.services.host=" + invalid_url;
     }
     return args;
 }

--- a/launcher/minecraft/auth/AuthSession.cpp
+++ b/launcher/minecraft/auth/AuthSession.cpp
@@ -27,6 +27,7 @@ bool AuthSession::MakeOffline(QString offline_playername)
     access_token = "0";
     player_name = offline_playername;
     status = PlayableOffline;
+    wants_online = false;
     return true;
 }
 

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -117,9 +117,9 @@ void LauncherPartLaunch::executeTask()
     }
 
     m_launchScript = minecraftInstance->createLaunchScript(m_session, m_serverToJoin);
-    QStringList args = minecraftInstance->javaArguments();
 
-    args.append(minecraftInstance->processAuthArgs(m_session));
+    auto args = minecraftInstance->processAuthArgs(m_session);
+    args.append(minecraftInstance->javaArguments());
 
     QString allArgs = args.join(", ");
     emit logLine("Java Arguments:\n[" + m_parent->censorPrivateInfo(allArgs) + "]\n\n", MessageLevel::Launcher);


### PR DESCRIPTION
Resolves https://github.com/fn2006/PollyMC/issues/150

If the game is launched in offline mode, pass invalid API servers via the `-Dminecraft.api.*` system properties. This workaround is mentioned here: https://github.com/FabricMC/fabric-loom/issues/915#issuecomment-1609154390

I think this change is appropriate to make here in PollyMC even though the Fabric developers decided against using it there. If a user wants to override the API servers back to the vanilla values (in order to use Auth Me or something), they can do so by setting the following custom JVM args on the instance:

```
-Dminecraft.api.env=PROD
-Dminecraft.api.auth.host=https://authserver.mojang.com
-Dminecraft.api.account.host=https://api.mojang.com
-Dminecraft.api.session.host=https://sessionserver.mojang.com
-Dminecraft.api.services.host=https://api.minecraftservices.com
```

Previously, auth args would override any user-specified args, but this patch also changes that behavior so user-specified args are now passed last.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
