### PR TITLE
Use either authlib-injector or system properties, not both

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -544,11 +544,7 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
     if (session->uses_custom_api_servers) {
-        args << "-Dminecraft.api.env=custom";
-        args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
-        args << "-Dminecraft.api.account.host=" + session->account_server_url;
-        args << "-Dminecraft.api.session.host=" + session->session_server_url;
-        args << "-Dminecraft.api.services.host=" + session->services_server_url;
+        bool using_authlib_injector = false;
         auto agents = m_components->getProfile()->getAgents();
         for (auto agent : agents) {
             if (agent->library()->artifactPrefix() == "moe.yushi:authlibinjector") {
@@ -562,8 +558,17 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
                 if (session->authlib_injector_metadata != "") {
                     args << "-Dauthlibinjector.yggdrasil.prefetched=" + session->authlib_injector_metadata;
                 }
+                using_authlib_injector = true;
                 break;
             }
+        }
+        if (!using_authlib_injector) {
+            qDebug() << "authlib-injector not found, setting -Dminecraft.api.*.host system properties.";
+            args << "-Dminecraft.api.env=custom";
+            args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
+            args << "-Dminecraft.api.account.host=" + session->account_server_url;
+            args << "-Dminecraft.api.session.host=" + session->session_server_url;
+            args << "-Dminecraft.api.services.host=" + session->services_server_url;
         }
     }
     return args;


### PR DESCRIPTION
Resolves https://github.com/fn2006/PollyMC/issues/154

In 1.20+, authlib-injector wants to intercept
https://api.minecraftservices.com/publickeys [0], but if we override the services server using `-Dminecraft.api.services.host`, the request does not get intercepted.

That's not an issue for API servers that implement the `/publickeys` route, but Ely.by does not. A decent solution is to not set these `-Dminecraft.api.*.host` system properties when authlib-injector is available, since authlib-injector expects authlib to make requests to Mojang's API servers.

[0] https://github.com/yushijinhun/authlib-injector/commit/18a0ce266963e98c47b65df7a71450a857e100ef

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
